### PR TITLE
Hass 2024.11 update progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![GitHub Release](https://img.shields.io/github/v/release/Domochip/WPalaControl)
-![Home Assistant](https://img.shields.io/badge/home_assistant-2021.11-blue.svg?logo=homeassistant)
+![Home Assistant](https://img.shields.io/badge/home_assistant-2024.11-blue.svg?logo=homeassistant)
 
 # WPalaControl
 


### PR DESCRIPTION
Online Update triggered via Home Assistant Update entity now displays the progress.
Home Assistant 2024.11 minimum is required to see it