### PR TITLE
Improve Home Assistant tempertaure entities for Hydro stove

### DIFF
--- a/src/WPalaControl.cpp
+++ b/src/WPalaControl.cpp
@@ -484,93 +484,45 @@ bool WPalaControl::mqttPublishHassDiscovery()
   //
   // Room temperature entity
   //
-  if (!isFluidType)
+
+  uniqueId = uniqueIdPrefixStove;
+  uniqueId += F("_RoomTemp");
+
+  topic = _ha.mqtt.hassDiscoveryPrefix;
+  topic += F("/sensor/");
+  topic += uniqueId;
+  topic += F("/config");
+
+  // prepare payload for Stove room temperature sensor
+  jsonDoc[F("~")] = baseTopic.substring(0, baseTopic.length() - 1); // remove ending '/'
+  jsonDoc[F("availability")] = serialized(availability);
+  jsonDoc[F("device")] = serialized(device);
+  jsonDoc[F("device_class")] = F("temperature");
+  jsonDoc[F("name")] = F("Room Temperature");
+  jsonDoc[F("object_id")] = F("stove_roomtemp");
+  jsonDoc[F("suggested_display_precision")] = 1;
+  jsonDoc[F("state_class")] = F("measurement");
+  jsonDoc[F("unique_id")] = uniqueId;
+  jsonDoc[F("unit_of_measurement")] = F("°C");
+  if (_ha.mqtt.type == HA_MQTT_GENERIC)
+    jsonDoc[F("state_topic")] = String(F("~/T")) + (char)('1' + MAINTPROBE);
+  else if (_ha.mqtt.type == HA_MQTT_GENERIC_JSON)
   {
-    uniqueId = uniqueIdPrefixStove;
-    uniqueId += F("_RoomTemp");
-
-    topic = _ha.mqtt.hassDiscoveryPrefix;
-    topic += F("/sensor/");
-    topic += uniqueId;
-    topic += F("/config");
-
-    // prepare payload for Stove room temperature sensor
-    jsonDoc[F("~")] = baseTopic.substring(0, baseTopic.length() - 1); // remove ending '/'
-    jsonDoc[F("availability")] = serialized(availability);
-    jsonDoc[F("device")] = serialized(device);
-    jsonDoc[F("device_class")] = F("temperature");
-    jsonDoc[F("name")] = F("Room Temperature");
-    jsonDoc[F("object_id")] = F("stove_roomtemp");
-    jsonDoc[F("suggested_display_precision")] = 1;
-    jsonDoc[F("state_class")] = F("measurement");
-    jsonDoc[F("unique_id")] = uniqueId;
-    jsonDoc[F("unit_of_measurement")] = F("°C");
-    if (_ha.mqtt.type == HA_MQTT_GENERIC)
-      jsonDoc[F("state_topic")] = String(F("~/T")) + (char)('1' + MAINTPROBE);
-    else if (_ha.mqtt.type == HA_MQTT_GENERIC_JSON)
-    {
-      jsonDoc[F("state_topic")] = F("~/TMPS");
-      jsonDoc[F("value_template")] = String(F("{{ value_json.T")) + (char)('1' + MAINTPROBE) + F(" }}");
-    }
-    else if (_ha.mqtt.type == HA_MQTT_GENERIC_CATEGORIZED)
-      jsonDoc[F("state_topic")] = String(F("~/TMPS/T")) + (char)('1' + MAINTPROBE);
-
-    jsonDoc.shrinkToFit();
-    serializeJson(jsonDoc, payload);
-
-    // publish
-    _mqttMan.publish(topic.c_str(), payload.c_str(), true);
-
-    // clean
-    jsonDoc.clear();
-    payload = "";
+    jsonDoc[F("state_topic")] = F("~/TMPS");
+    jsonDoc[F("value_template")] = String(F("{{ value_json.T")) + (char)('1' + MAINTPROBE) + F(" }}");
   }
+  else if (_ha.mqtt.type == HA_MQTT_GENERIC_CATEGORIZED)
+    jsonDoc[F("state_topic")] = String(F("~/TMPS/T")) + (char)('1' + MAINTPROBE);
 
-  //
-  // Water temperature entity
-  //
+  jsonDoc.shrinkToFit();
+  serializeJson(jsonDoc, payload);
 
-  if (isFluidType)
-  {
-    uniqueId = uniqueIdPrefixStove;
-    uniqueId += F("_WaterTemp");
+  // publish
+  _mqttMan.publish(topic.c_str(), payload.c_str(), true);
 
-    topic = _ha.mqtt.hassDiscoveryPrefix;
-    topic += F("/sensor/");
-    topic += uniqueId;
-    topic += F("/config");
-
-    // prepare payload for Stove water temperature sensor
-    jsonDoc[F("~")] = baseTopic.substring(0, baseTopic.length() - 1); // remove ending '/'
-    jsonDoc[F("availability")] = serialized(availability);
-    jsonDoc[F("device")] = serialized(device);
-    jsonDoc[F("device_class")] = F("temperature");
-    jsonDoc[F("name")] = F("Water Temperature");
-    jsonDoc[F("object_id")] = F("stove_watertemp");
-    jsonDoc[F("suggested_display_precision")] = 1;
-    jsonDoc[F("state_class")] = F("measurement");
-    jsonDoc[F("unique_id")] = uniqueId;
-    jsonDoc[F("unit_of_measurement")] = F("°C");
-    if (_ha.mqtt.type == HA_MQTT_GENERIC)
-      jsonDoc[F("state_topic")] = String(F("~/T")) + (char)('1' + MAINTPROBE);
-    else if (_ha.mqtt.type == HA_MQTT_GENERIC_JSON)
-    {
-      jsonDoc[F("state_topic")] = F("~/TMPS");
-      jsonDoc[F("value_template")] = String(F("{{ value_json.T")) + (char)('1' + MAINTPROBE) + F(" }}");
-    }
-    else if (_ha.mqtt.type == HA_MQTT_GENERIC_CATEGORIZED)
-      jsonDoc[F("state_topic")] = String(F("~/TMPS/T")) + (char)('1' + MAINTPROBE);
-
-    jsonDoc.shrinkToFit();
-    serializeJson(jsonDoc, payload);
-
-    // publish
-    _mqttMan.publish(topic.c_str(), payload.c_str(), true);
-
-    // clean
-    jsonDoc.clear();
-    payload = "";
-  }
+  // clean
+  jsonDoc.clear();
+  payload = "";
 
   //
   // Pellet consumption entity

--- a/src/WPalaControl.cpp
+++ b/src/WPalaControl.cpp
@@ -482,8 +482,20 @@ bool WPalaControl::mqttPublishHassDiscovery()
   payload = "";
 
   //
-  // Room temperature entity
+  // Main temperature sensor entity
   //
+
+  const __FlashStringHelper *tempSensorNameList[] = {F("Ambiant"), F("Tank Water"), F("Flow Water"), F("Return Water")};
+
+  // find the name
+  byte tempSensorNameIndex = 0; // default to Ambiant
+  if (isHydroType)
+  {
+    if (UICONFIG == 1)
+      tempSensorNameIndex = 3; // Return
+    else if (UICONFIG == 3 || UICONFIG == 4)
+      tempSensorNameIndex = 1; // Tank
+  }
 
   uniqueId = uniqueIdPrefixStove;
   uniqueId += F("_RoomTemp");

--- a/src/WPalaControl.cpp
+++ b/src/WPalaControl.cpp
@@ -542,95 +542,95 @@ bool WPalaControl::mqttPublishHassDiscovery()
   jsonDoc.clear();
   payload = "";
 
-  // additionnal entities for Hydro type
-  if (isHydroType)
-  {
-    //
-    // Flow water temperature sensor entity
-    //
+  // // additionnal entities for Hydro type
+  // if (isHydroType)
+  // {
+  //   //
+  //   // Flow water temperature sensor entity
+  //   //
 
-    uniqueId = uniqueIdPrefixStove;
-    uniqueId += F("_FlowWaterTemp");
+  //   uniqueId = uniqueIdPrefixStove;
+  //   uniqueId += F("_FlowWaterTemp");
 
-    topic = _ha.mqtt.hassDiscoveryPrefix;
-    topic += F("/sensor/");
-    topic += uniqueId;
-    topic += F("/config");
+  //   topic = _ha.mqtt.hassDiscoveryPrefix;
+  //   topic += F("/sensor/");
+  //   topic += uniqueId;
+  //   topic += F("/config");
 
-    // prepare payload for Stove flow water temperature sensor
-    jsonDoc[F("~")] = baseTopic.substring(0, baseTopic.length() - 1); // remove ending '/'
-    jsonDoc[F("availability")] = serialized(availability);
-    jsonDoc[F("device")] = serialized(device);
-    jsonDoc[F("device_class")] = F("temperature");
-    jsonDoc[F("name")] = F("Flow Water Temperature");
-    jsonDoc[F("object_id")] = F("stove_flowwatertemp");
-    jsonDoc[F("suggested_display_precision")] = 1;
-    jsonDoc[F("state_class")] = F("measurement");
-    jsonDoc[F("unique_id")] = uniqueId;
-    jsonDoc[F("unit_of_measurement")] = F("°C");
-    if (_ha.mqtt.type == HA_MQTT_GENERIC)
-      jsonDoc[F("state_topic")] = F("~/T1");
-    else if (_ha.mqtt.type == HA_MQTT_GENERIC_JSON)
-    {
-      jsonDoc[F("state_topic")] = F("~/TMPS");
-      jsonDoc[F("value_template")] = F("{{ value_json.T1 }}");
-    }
-    else if (_ha.mqtt.type == HA_MQTT_GENERIC_CATEGORIZED)
-      jsonDoc[F("state_topic")] = F("~/TMPS/T1");
+  //   // prepare payload for Stove flow water temperature sensor
+  //   jsonDoc[F("~")] = baseTopic.substring(0, baseTopic.length() - 1); // remove ending '/'
+  //   jsonDoc[F("availability")] = serialized(availability);
+  //   jsonDoc[F("device")] = serialized(device);
+  //   jsonDoc[F("device_class")] = F("temperature");
+  //   jsonDoc[F("name")] = F("Flow Water Temperature");
+  //   jsonDoc[F("object_id")] = F("stove_flowwatertemp");
+  //   jsonDoc[F("suggested_display_precision")] = 1;
+  //   jsonDoc[F("state_class")] = F("measurement");
+  //   jsonDoc[F("unique_id")] = uniqueId;
+  //   jsonDoc[F("unit_of_measurement")] = F("°C");
+  //   if (_ha.mqtt.type == HA_MQTT_GENERIC)
+  //     jsonDoc[F("state_topic")] = F("~/T1");
+  //   else if (_ha.mqtt.type == HA_MQTT_GENERIC_JSON)
+  //   {
+  //     jsonDoc[F("state_topic")] = F("~/TMPS");
+  //     jsonDoc[F("value_template")] = F("{{ value_json.T1 }}");
+  //   }
+  //   else if (_ha.mqtt.type == HA_MQTT_GENERIC_CATEGORIZED)
+  //     jsonDoc[F("state_topic")] = F("~/TMPS/T1");
 
-    jsonDoc.shrinkToFit();
-    serializeJson(jsonDoc, payload);
+  //   jsonDoc.shrinkToFit();
+  //   serializeJson(jsonDoc, payload);
 
-    // publish
-    _mqttMan.publish(topic.c_str(), payload.c_str(), true);
+  //   // publish
+  //   _mqttMan.publish(topic.c_str(), payload.c_str(), true);
 
-    // clean
-    jsonDoc.clear();
-    payload = "";
+  //   // clean
+  //   jsonDoc.clear();
+  //   payload = "";
 
-    //
-    // Return water temperature sensor entity
-    //
+  //   //
+  //   // Return water temperature sensor entity
+  //   //
 
-    uniqueId = uniqueIdPrefixStove;
-    uniqueId += F("_ReturnWaterTemp");
+  //   uniqueId = uniqueIdPrefixStove;
+  //   uniqueId += F("_ReturnWaterTemp");
 
-    topic = _ha.mqtt.hassDiscoveryPrefix;
-    topic += F("/sensor/");
-    topic += uniqueId;
-    topic += F("/config");
+  //   topic = _ha.mqtt.hassDiscoveryPrefix;
+  //   topic += F("/sensor/");
+  //   topic += uniqueId;
+  //   topic += F("/config");
 
-    // prepare payload for Stove return water temperature sensor
-    jsonDoc[F("~")] = baseTopic.substring(0, baseTopic.length() - 1); // remove ending '/'
-    jsonDoc[F("availability")] = serialized(availability);
-    jsonDoc[F("device")] = serialized(device);
-    jsonDoc[F("device_class")] = F("temperature");
-    jsonDoc[F("name")] = F("Return Water Temperature");
-    jsonDoc[F("object_id")] = F("stove_returnwatertemp");
-    jsonDoc[F("suggested_display_precision")] = 1;
-    jsonDoc[F("state_class")] = F("measurement");
-    jsonDoc[F("unique_id")] = uniqueId;
-    jsonDoc[F("unit_of_measurement")] = F("°C");
-    if (_ha.mqtt.type == HA_MQTT_GENERIC)
-      jsonDoc[F("state_topic")] = F("~/T2");
-    else if (_ha.mqtt.type == HA_MQTT_GENERIC_JSON)
-    {
-      jsonDoc[F("state_topic")] = F("~/TMPS");
-      jsonDoc[F("value_template")] = F("{{ value_json.T2 }}");
-    }
-    else if (_ha.mqtt.type == HA_MQTT_GENERIC_CATEGORIZED)
-      jsonDoc[F("state_topic")] = F("~/TMPS/T2");
+  //   // prepare payload for Stove return water temperature sensor
+  //   jsonDoc[F("~")] = baseTopic.substring(0, baseTopic.length() - 1); // remove ending '/'
+  //   jsonDoc[F("availability")] = serialized(availability);
+  //   jsonDoc[F("device")] = serialized(device);
+  //   jsonDoc[F("device_class")] = F("temperature");
+  //   jsonDoc[F("name")] = F("Return Water Temperature");
+  //   jsonDoc[F("object_id")] = F("stove_returnwatertemp");
+  //   jsonDoc[F("suggested_display_precision")] = 1;
+  //   jsonDoc[F("state_class")] = F("measurement");
+  //   jsonDoc[F("unique_id")] = uniqueId;
+  //   jsonDoc[F("unit_of_measurement")] = F("°C");
+  //   if (_ha.mqtt.type == HA_MQTT_GENERIC)
+  //     jsonDoc[F("state_topic")] = F("~/T2");
+  //   else if (_ha.mqtt.type == HA_MQTT_GENERIC_JSON)
+  //   {
+  //     jsonDoc[F("state_topic")] = F("~/TMPS");
+  //     jsonDoc[F("value_template")] = F("{{ value_json.T2 }}");
+  //   }
+  //   else if (_ha.mqtt.type == HA_MQTT_GENERIC_CATEGORIZED)
+  //     jsonDoc[F("state_topic")] = F("~/TMPS/T2");
 
-    jsonDoc.shrinkToFit();
-    serializeJson(jsonDoc, payload);
+  //   jsonDoc.shrinkToFit();
+  //   serializeJson(jsonDoc, payload);
 
-    // publish
-    _mqttMan.publish(topic.c_str(), payload.c_str(), true);
+  //   // publish
+  //   _mqttMan.publish(topic.c_str(), payload.c_str(), true);
 
-    // clean
-    jsonDoc.clear();
-    payload = "";
-  }
+  //   // clean
+  //   jsonDoc.clear();
+  //   payload = "";
+  // }
 
   //
   // Pellet consumption entity

--- a/src/WPalaControl.cpp
+++ b/src/WPalaControl.cpp
@@ -492,9 +492,9 @@ bool WPalaControl::mqttPublishHassDiscovery()
   if (isHydroType)
   {
     if (UICONFIG == 1)
-      tempSensorNameIndex = 3; // Return
+      tempSensorNameIndex = 3; // Return Water
     else if (UICONFIG == 3 || UICONFIG == 4)
-      tempSensorNameIndex = 1; // Tank
+      tempSensorNameIndex = 1; // Tank Water
   }
 
   uniqueId = uniqueIdPrefixStove;
@@ -541,6 +541,96 @@ bool WPalaControl::mqttPublishHassDiscovery()
   // clean
   jsonDoc.clear();
   payload = "";
+
+  // additionnal entities for Hydro type
+  if (isHydroType)
+  {
+    //
+    // Flow water temperature sensor entity
+    //
+
+    uniqueId = uniqueIdPrefixStove;
+    uniqueId += F("_FlowWaterTemp");
+
+    topic = _ha.mqtt.hassDiscoveryPrefix;
+    topic += F("/sensor/");
+    topic += uniqueId;
+    topic += F("/config");
+
+    // prepare payload for Stove flow water temperature sensor
+    jsonDoc[F("~")] = baseTopic.substring(0, baseTopic.length() - 1); // remove ending '/'
+    jsonDoc[F("availability")] = serialized(availability);
+    jsonDoc[F("device")] = serialized(device);
+    jsonDoc[F("device_class")] = F("temperature");
+    jsonDoc[F("name")] = F("Flow Water Temperature");
+    jsonDoc[F("object_id")] = F("stove_flowwatertemp");
+    jsonDoc[F("suggested_display_precision")] = 1;
+    jsonDoc[F("state_class")] = F("measurement");
+    jsonDoc[F("unique_id")] = uniqueId;
+    jsonDoc[F("unit_of_measurement")] = F("°C");
+    if (_ha.mqtt.type == HA_MQTT_GENERIC)
+      jsonDoc[F("state_topic")] = F("~/T1");
+    else if (_ha.mqtt.type == HA_MQTT_GENERIC_JSON)
+    {
+      jsonDoc[F("state_topic")] = F("~/TMPS");
+      jsonDoc[F("value_template")] = F("{{ value_json.T1 }}");
+    }
+    else if (_ha.mqtt.type == HA_MQTT_GENERIC_CATEGORIZED)
+      jsonDoc[F("state_topic")] = F("~/TMPS/T1");
+
+    jsonDoc.shrinkToFit();
+    serializeJson(jsonDoc, payload);
+
+    // publish
+    _mqttMan.publish(topic.c_str(), payload.c_str(), true);
+
+    // clean
+    jsonDoc.clear();
+    payload = "";
+
+    //
+    // Return water temperature sensor entity
+    //
+
+    uniqueId = uniqueIdPrefixStove;
+    uniqueId += F("_ReturnWaterTemp");
+
+    topic = _ha.mqtt.hassDiscoveryPrefix;
+    topic += F("/sensor/");
+    topic += uniqueId;
+    topic += F("/config");
+
+    // prepare payload for Stove return water temperature sensor
+    jsonDoc[F("~")] = baseTopic.substring(0, baseTopic.length() - 1); // remove ending '/'
+    jsonDoc[F("availability")] = serialized(availability);
+    jsonDoc[F("device")] = serialized(device);
+    jsonDoc[F("device_class")] = F("temperature");
+    jsonDoc[F("name")] = F("Return Water Temperature");
+    jsonDoc[F("object_id")] = F("stove_returnwatertemp");
+    jsonDoc[F("suggested_display_precision")] = 1;
+    jsonDoc[F("state_class")] = F("measurement");
+    jsonDoc[F("unique_id")] = uniqueId;
+    jsonDoc[F("unit_of_measurement")] = F("°C");
+    if (_ha.mqtt.type == HA_MQTT_GENERIC)
+      jsonDoc[F("state_topic")] = F("~/T2");
+    else if (_ha.mqtt.type == HA_MQTT_GENERIC_JSON)
+    {
+      jsonDoc[F("state_topic")] = F("~/TMPS");
+      jsonDoc[F("value_template")] = F("{{ value_json.T2 }}");
+    }
+    else if (_ha.mqtt.type == HA_MQTT_GENERIC_CATEGORIZED)
+      jsonDoc[F("state_topic")] = F("~/TMPS/T2");
+
+    jsonDoc.shrinkToFit();
+    serializeJson(jsonDoc, payload);
+
+    // publish
+    _mqttMan.publish(topic.c_str(), payload.c_str(), true);
+
+    // clean
+    jsonDoc.clear();
+    payload = "";
+  }
 
   //
   // Pellet consumption entity

--- a/src/WPalaControl.cpp
+++ b/src/WPalaControl.cpp
@@ -485,10 +485,10 @@ bool WPalaControl::mqttPublishHassDiscovery()
   // Main temperature sensor entity
   //
 
-  const __FlashStringHelper *tempSensorNameList[] = {F("Ambiant"), F("Tank Water"), F("Flow Water"), F("Return Water")};
+  const __FlashStringHelper *tempSensorNameList[] = {F("Room"), F("Tank Water"), F("Flow Water"), F("Return Water")};
 
   // find the name
-  byte tempSensorNameIndex = 0; // default to Ambiant
+  byte tempSensorNameIndex = 0; // default to Room
   if (isHydroType)
   {
     if (UICONFIG == 1)

--- a/src/WPalaControl.cpp
+++ b/src/WPalaControl.cpp
@@ -319,11 +319,12 @@ bool WPalaControl::mqttPublishHassDiscovery()
   uint16_t MOD, VER;
   char FWDATE[11];
   uint16_t FLUID;
+  uint16_t SPLMIN, SPLMAX;
   byte MAINTPROBE;
   byte STOVETYPE;
   byte FAN2TYPE;
   byte FAN2MODE;
-  if (Palazzetti::CommandResult::OK != _Pala.getStaticData(&SN, &SNCHK, nullptr, &MOD, &VER, nullptr, &FWDATE, &FLUID, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, &MAINTPROBE, &STOVETYPE, &FAN2TYPE, &FAN2MODE, nullptr, nullptr, nullptr, nullptr, nullptr))
+  if (Palazzetti::CommandResult::OK != _Pala.getStaticData(&SN, &SNCHK, nullptr, &MOD, &VER, nullptr, &FWDATE, &FLUID, &SPLMIN, &SPLMAX, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, &MAINTPROBE, &STOVETYPE, &FAN2TYPE, &FAN2MODE, nullptr, nullptr, nullptr, nullptr, nullptr))
     return false;
 
   // read all status from stove
@@ -348,6 +349,7 @@ bool WPalaControl::mqttPublishHassDiscovery()
   bool hasFan4 = (FAN2TYPE > 2); // Fan order is not the expected one
   bool ifFan4SwitchEntity = (FANLMINMAX[4] == 0 && FANLMINMAX[5] == 1);
   bool isAirType = (STOVETYPE == 1 || STOVETYPE == 3 || STOVETYPE == 5 || STOVETYPE == 7 || STOVETYPE == 8);
+  bool isFluidType = (FLUID == 1);
   bool hasFanAuto = (FAN2MODE == 2 || FAN2MODE == 3);
 
   // ---------- Stove Device ----------
@@ -481,45 +483,93 @@ bool WPalaControl::mqttPublishHassDiscovery()
   //
   // Room temperature entity
   //
-
-  uniqueId = uniqueIdPrefixStove;
-  uniqueId += F("_RoomTemp");
-
-  topic = _ha.mqtt.hassDiscoveryPrefix;
-  topic += F("/sensor/");
-  topic += uniqueId;
-  topic += F("/config");
-
-  // prepare payload for Stove room temperature sensor
-  jsonDoc[F("~")] = baseTopic.substring(0, baseTopic.length() - 1); // remove ending '/'
-  jsonDoc[F("availability")] = serialized(availability);
-  jsonDoc[F("device")] = serialized(device);
-  jsonDoc[F("device_class")] = F("temperature");
-  jsonDoc[F("name")] = F("Room Temperature");
-  jsonDoc[F("object_id")] = F("stove_roomtemp");
-  jsonDoc[F("suggested_display_precision")] = 1;
-  jsonDoc[F("state_class")] = F("measurement");
-  jsonDoc[F("unique_id")] = uniqueId;
-  jsonDoc[F("unit_of_measurement")] = F("°C");
-  if (_ha.mqtt.type == HA_MQTT_GENERIC)
-    jsonDoc[F("state_topic")] = String(F("~/T")) + (char)('1' + MAINTPROBE);
-  else if (_ha.mqtt.type == HA_MQTT_GENERIC_JSON)
+  if (!isFluidType)
   {
-    jsonDoc[F("state_topic")] = F("~/TMPS");
-    jsonDoc[F("value_template")] = String(F("{{ value_json.T")) + (char)('1' + MAINTPROBE) + F(" }}");
+    uniqueId = uniqueIdPrefixStove;
+    uniqueId += F("_RoomTemp");
+
+    topic = _ha.mqtt.hassDiscoveryPrefix;
+    topic += F("/sensor/");
+    topic += uniqueId;
+    topic += F("/config");
+
+    // prepare payload for Stove room temperature sensor
+    jsonDoc[F("~")] = baseTopic.substring(0, baseTopic.length() - 1); // remove ending '/'
+    jsonDoc[F("availability")] = serialized(availability);
+    jsonDoc[F("device")] = serialized(device);
+    jsonDoc[F("device_class")] = F("temperature");
+    jsonDoc[F("name")] = F("Room Temperature");
+    jsonDoc[F("object_id")] = F("stove_roomtemp");
+    jsonDoc[F("suggested_display_precision")] = 1;
+    jsonDoc[F("state_class")] = F("measurement");
+    jsonDoc[F("unique_id")] = uniqueId;
+    jsonDoc[F("unit_of_measurement")] = F("°C");
+    if (_ha.mqtt.type == HA_MQTT_GENERIC)
+      jsonDoc[F("state_topic")] = String(F("~/T")) + (char)('1' + MAINTPROBE);
+    else if (_ha.mqtt.type == HA_MQTT_GENERIC_JSON)
+    {
+      jsonDoc[F("state_topic")] = F("~/TMPS");
+      jsonDoc[F("value_template")] = String(F("{{ value_json.T")) + (char)('1' + MAINTPROBE) + F(" }}");
+    }
+    else if (_ha.mqtt.type == HA_MQTT_GENERIC_CATEGORIZED)
+      jsonDoc[F("state_topic")] = String(F("~/TMPS/T")) + (char)('1' + MAINTPROBE);
+
+    jsonDoc.shrinkToFit();
+    serializeJson(jsonDoc, payload);
+
+    // publish
+    _mqttMan.publish(topic.c_str(), payload.c_str(), true);
+
+    // clean
+    jsonDoc.clear();
+    payload = "";
   }
-  else if (_ha.mqtt.type == HA_MQTT_GENERIC_CATEGORIZED)
-    jsonDoc[F("state_topic")] = String(F("~/TMPS/T")) + (char)('1' + MAINTPROBE);
 
-  jsonDoc.shrinkToFit();
-  serializeJson(jsonDoc, payload);
+  //
+  // Water temperature entity
+  //
 
-  // publish
-  _mqttMan.publish(topic.c_str(), payload.c_str(), true);
+  if (isFluidType)
+  {
+    uniqueId = uniqueIdPrefixStove;
+    uniqueId += F("_WaterTemp");
 
-  // clean
-  jsonDoc.clear();
-  payload = "";
+    topic = _ha.mqtt.hassDiscoveryPrefix;
+    topic += F("/sensor/");
+    topic += uniqueId;
+    topic += F("/config");
+
+    // prepare payload for Stove water temperature sensor
+    jsonDoc[F("~")] = baseTopic.substring(0, baseTopic.length() - 1); // remove ending '/'
+    jsonDoc[F("availability")] = serialized(availability);
+    jsonDoc[F("device")] = serialized(device);
+    jsonDoc[F("device_class")] = F("temperature");
+    jsonDoc[F("name")] = F("Water Temperature");
+    jsonDoc[F("object_id")] = F("stove_watertemp");
+    jsonDoc[F("suggested_display_precision")] = 1;
+    jsonDoc[F("state_class")] = F("measurement");
+    jsonDoc[F("unique_id")] = uniqueId;
+    jsonDoc[F("unit_of_measurement")] = F("°C");
+    if (_ha.mqtt.type == HA_MQTT_GENERIC)
+      jsonDoc[F("state_topic")] = String(F("~/T")) + (char)('1' + MAINTPROBE);
+    else if (_ha.mqtt.type == HA_MQTT_GENERIC_JSON)
+    {
+      jsonDoc[F("state_topic")] = F("~/TMPS");
+      jsonDoc[F("value_template")] = String(F("{{ value_json.T")) + (char)('1' + MAINTPROBE) + F(" }}");
+    }
+    else if (_ha.mqtt.type == HA_MQTT_GENERIC_CATEGORIZED)
+      jsonDoc[F("state_topic")] = String(F("~/TMPS/T")) + (char)('1' + MAINTPROBE);
+
+    jsonDoc.shrinkToFit();
+    serializeJson(jsonDoc, payload);
+
+    // publish
+    _mqttMan.publish(topic.c_str(), payload.c_str(), true);
+
+    // clean
+    jsonDoc.clear();
+    payload = "";
+  }
 
   //
   // Pellet consumption entity
@@ -625,8 +675,8 @@ bool WPalaControl::mqttPublishHassDiscovery()
     jsonDoc[F("command_topic")] = F("~/cmd");
     jsonDoc[F("device")] = serialized(device);
     jsonDoc[F("device_class")] = F("temperature");
-    jsonDoc[F("min")] = 17;
-    jsonDoc[F("max")] = 23;
+    jsonDoc[F("min")] = SPLMIN > 0 ? SPLMIN : 17;
+    jsonDoc[F("max")] = SPLMAX > 0 ? SPLMAX : 23;
     jsonDoc[F("mode")] = F("slider");
     jsonDoc[F("name")] = F("SetPoint");
     jsonDoc[F("object_id")] = F("stove_setp");
@@ -2678,7 +2728,7 @@ void WPalaControl::appInitWebServer(WebServer &server)
           JsonArray PARM = doc[F("PARM")].to<JsonArray>();
           for (byte i = 0; i < 0x6A; i++)
             PARM.add(params[i]);
-          
+
           serializeJson(doc, toReturn);
 
           SERVER_KEEPALIVE_FALSE()

--- a/src/WPalaControl.cpp
+++ b/src/WPalaControl.cpp
@@ -485,7 +485,7 @@ bool WPalaControl::mqttPublishHassDiscovery()
   // Main temperature sensor entity
   //
 
-  const __FlashStringHelper *tempSensorNameList[] = {F("Room"), F("Tank Water"), F("Flow Water"), F("Return Water")};
+  const __FlashStringHelper *tempSensorNameList[] = {F("Room"), F("Storage Tank"), F("Flow Water"), F("Return Water")};
 
   // find the name
   byte tempSensorNameIndex = 0; // default to Room

--- a/src/WPalaControl.cpp
+++ b/src/WPalaControl.cpp
@@ -674,8 +674,8 @@ bool WPalaControl::mqttPublishHassDiscovery()
     jsonDoc[F("command_topic")] = F("~/cmd");
     jsonDoc[F("device")] = serialized(device);
     jsonDoc[F("device_class")] = F("temperature");
-    jsonDoc[F("min")] = SPLMIN > 0 ? SPLMIN : 17;
-    jsonDoc[F("max")] = SPLMAX > 0 ? SPLMAX : 23;
+    jsonDoc[F("min")] = SPLMAX > 51 ? SPLMIN : 17;
+    jsonDoc[F("max")] = SPLMAX > 51 ? SPLMAX : 23;
     jsonDoc[F("mode")] = F("slider");
     jsonDoc[F("name")] = F("SetPoint");
     jsonDoc[F("object_id")] = F("stove_setp");

--- a/src/WPalaControl.cpp
+++ b/src/WPalaControl.cpp
@@ -702,8 +702,8 @@ bool WPalaControl::mqttPublishHassDiscovery()
     jsonDoc[F("command_topic")] = F("~/cmd");
     jsonDoc[F("device")] = serialized(device);
     jsonDoc[F("device_class")] = F("temperature");
-    jsonDoc[F("min")] = SPLMAX > 51 ? SPLMIN : 17;
-    jsonDoc[F("max")] = SPLMAX > 51 ? SPLMAX : 23;
+    jsonDoc[F("min")] = (isHydroType && (UICONFIG == 1 || UICONFIG == 3 || UICONFIG == 4)) ? SPLMIN : 17; // use stove limit if it is an hydro one and config use water temp
+    jsonDoc[F("max")] = (isHydroType && (UICONFIG == 1 || UICONFIG == 3 || UICONFIG == 4)) ? SPLMAX : 23;
     jsonDoc[F("mode")] = F("slider");
     jsonDoc[F("name")] = F("SetPoint");
     jsonDoc[F("object_id")] = F("stove_setp");

--- a/src/WPalaControl.cpp
+++ b/src/WPalaControl.cpp
@@ -498,20 +498,26 @@ bool WPalaControl::mqttPublishHassDiscovery()
   }
 
   uniqueId = uniqueIdPrefixStove;
-  uniqueId += F("_RoomTemp");
+  uniqueId += '_';
+  uniqueId += tempSensorNameList[tempSensorNameIndex];
+  uniqueId.replace(F(" "), "");
+  uniqueId += F("Temp");
 
   topic = _ha.mqtt.hassDiscoveryPrefix;
   topic += F("/sensor/");
   topic += uniqueId;
   topic += F("/config");
 
-  // prepare payload for Stove room temperature sensor
+  // prepare payload for Stove main temperature sensor
   jsonDoc[F("~")] = baseTopic.substring(0, baseTopic.length() - 1); // remove ending '/'
   jsonDoc[F("availability")] = serialized(availability);
   jsonDoc[F("device")] = serialized(device);
   jsonDoc[F("device_class")] = F("temperature");
-  jsonDoc[F("name")] = F("Room Temperature");
-  jsonDoc[F("object_id")] = F("stove_roomtemp");
+  jsonDoc[F("name")] = String(tempSensorNameList[tempSensorNameIndex]) + F(" Temperature");
+  String objectIdSuffix = tempSensorNameList[tempSensorNameIndex];
+  objectIdSuffix.replace(F(" "), "");
+  objectIdSuffix.toLowerCase();
+  jsonDoc[F("object_id")] = String(F("stove_")) + objectIdSuffix;
   jsonDoc[F("suggested_display_precision")] = 1;
   jsonDoc[F("state_class")] = F("measurement");
   jsonDoc[F("unique_id")] = uniqueId;

--- a/src/WPalaControl.cpp
+++ b/src/WPalaControl.cpp
@@ -349,7 +349,6 @@ bool WPalaControl::mqttPublishHassDiscovery()
   bool hasFan4 = (FAN2TYPE > 2); // Fan order is not the expected one
   bool ifFan4SwitchEntity = (FANLMINMAX[4] == 0 && FANLMINMAX[5] == 1);
   bool isAirType = (STOVETYPE == 1 || STOVETYPE == 3 || STOVETYPE == 5 || STOVETYPE == 7 || STOVETYPE == 8);
-  bool isFluidType = (FLUID == 1);
   bool hasFanAuto = (FAN2MODE == 2 || FAN2MODE == 3);
 
   // ---------- Stove Device ----------

--- a/src/WPalaControl.cpp
+++ b/src/WPalaControl.cpp
@@ -320,11 +320,12 @@ bool WPalaControl::mqttPublishHassDiscovery()
   char FWDATE[11];
   uint16_t FLUID;
   uint16_t SPLMIN, SPLMAX;
+  byte UICONFIG;
   byte MAINTPROBE;
   byte STOVETYPE;
   byte FAN2TYPE;
   byte FAN2MODE;
-  if (Palazzetti::CommandResult::OK != _Pala.getStaticData(&SN, &SNCHK, nullptr, &MOD, &VER, nullptr, &FWDATE, &FLUID, &SPLMIN, &SPLMAX, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, &MAINTPROBE, &STOVETYPE, &FAN2TYPE, &FAN2MODE, nullptr, nullptr, nullptr, nullptr, nullptr))
+  if (Palazzetti::CommandResult::OK != _Pala.getStaticData(&SN, &SNCHK, nullptr, &MOD, &VER, nullptr, &FWDATE, &FLUID, &SPLMIN, &SPLMAX, &UICONFIG, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, &MAINTPROBE, &STOVETYPE, &FAN2TYPE, &FAN2MODE, nullptr, nullptr, nullptr, nullptr, nullptr))
     return false;
 
   // read all status from stove
@@ -349,6 +350,7 @@ bool WPalaControl::mqttPublishHassDiscovery()
   bool hasFan4 = (FAN2TYPE > 2); // Fan order is not the expected one
   bool ifFan4SwitchEntity = (FANLMINMAX[4] == 0 && FANLMINMAX[5] == 1);
   bool isAirType = (STOVETYPE == 1 || STOVETYPE == 3 || STOVETYPE == 5 || STOVETYPE == 7 || STOVETYPE == 8);
+  bool isHydroType = (STOVETYPE == 2 || STOVETYPE == 4 || STOVETYPE == 6);
   bool hasFanAuto = (FAN2MODE == 2 || FAN2MODE == 3);
 
   // ---------- Stove Device ----------


### PR DESCRIPTION
This add `SPLMIN` and `SPLMAX` as variables which are used as the min and max available for the SetPoint if available, otherwise falling back to the hard coded values.

Adds a new boolean `isFluidType` based off the stove value `FLUID`.

It adds a new Water Temperature entity and wraps Room Temperature in a condition so that one or the other is used depending on the boolean `isFluidType`

I've never coded in C++ and I haven't tested this so let me know if something isn't right. It does compile though.

Ref #58 